### PR TITLE
switch to Array.from rather than spread operator

### DIFF
--- a/modules/cmpapi/src/encoder/datatype/EncodableFibonacciIntegerRange.ts
+++ b/modules/cmpapi/src/encoder/datatype/EncodableFibonacciIntegerRange.ts
@@ -37,6 +37,6 @@ export class EncodableFibonacciIntegerRange extends AbstractEncodableBitStringDa
 
   // Overriden
   public setValue(value: number[]) {
-    super.setValue([...new Set(value)].sort((n1, n2) => n1 - n2));
+    super.setValue(Array.from(new Set(value)).sort((n1, n2) => n1 - n2));
   }
 }

--- a/modules/cmpapi/src/encoder/datatype/EncodableFixedIntegerRange.ts
+++ b/modules/cmpapi/src/encoder/datatype/EncodableFixedIntegerRange.ts
@@ -37,6 +37,6 @@ export class EncodableFixedIntegerRange extends AbstractEncodableBitStringDataTy
 
   // Overriden
   public setValue(value: number[]) {
-    super.setValue([...new Set(value)].sort((n1, n2) => n1 - n2));
+    super.setValue(Array.from(new Set(value)).sort((n1, n2) => n1 - n2));
   }
 }

--- a/modules/cmpapi/src/encoder/datatype/EncodableOptimizedFibonacciRange.ts
+++ b/modules/cmpapi/src/encoder/datatype/EncodableOptimizedFibonacciRange.ts
@@ -69,6 +69,6 @@ export class EncodableOptimizedFibonacciRange extends AbstractEncodableBitString
 
   // Overriden
   public setValue(value: number[]) {
-    super.setValue([...new Set(value)].sort((n1, n2) => n1 - n2));
+    super.setValue(Array.from(new Set(value)).sort((n1, n2) => n1 - n2));
   }
 }

--- a/modules/cmpapi/src/encoder/datatype/EncodableOptimizedFixedRange.ts
+++ b/modules/cmpapi/src/encoder/datatype/EncodableOptimizedFixedRange.ts
@@ -69,6 +69,6 @@ export class EncodableOptimizedFixedRange extends AbstractEncodableBitStringData
 
   // Overriden
   public setValue(value: number[]) {
-    super.setValue([...new Set(value)].sort((n1, n2) => n1 - n2));
+    super.setValue(Array.from(new Set(value)).sort((n1, n2) => n1 - n2));
   }
 }


### PR DESCRIPTION
The spread operator requires babel to include a lot of extra code: https://babeljs.io/docs/assumptions#iterableisarray

Similarly with TypeScript: https://github.com/microsoft/TypeScript/issues/8856 (Fixed in https://github.com/microsoft/TypeScript/pull/31166).

Array.from is simpler and reduces the amount of code generated when transpiling. This would save us 811 bytes after gzip.  