### PR TITLE
Fix AbstractLazilyEncodableSection.toObj to better match specs

### DIFF
--- a/modules/cmpapi/src/encoder/section/AbstractLazilyEncodableSection.ts
+++ b/modules/cmpapi/src/encoder/section/AbstractLazilyEncodableSection.ts
@@ -80,14 +80,7 @@ export abstract class AbstractLazilyEncodableSection implements EncodableSection
 
   //Overriden
   public toObj(): any {
-    let obj = {};
-    for (let i = 0; i < this.segments.length; i++) {
-      let segmentObject = this.segments[i].toObj();
-      for (const [fieldName, value] of Object.entries(segmentObject)) {
-        obj[fieldName] = value;
-      }
-    }
-    return obj;
+    return this.segments.map((s) => s.toObj());
   }
 
   public encode(): string {


### PR DESCRIPTION
Towards https://github.com/IABTechLab/iabgpp-es/issues/48

This fixes `AbstractLazilyEncodableSection` to build an array of segments as defined in https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md#getsection- rather than a single object with all of its segments merged in.

`AbstractLazilyEncodableSection.toObj` which is used to populate `parsedSections` and returned by `getSection*` so this would be a breaking change.

I'm happy to add tests for `GppModel.toObject` as it seems to be intended to represent `parsedSections`.