### PR TITLE
fix: encode in abstractlazilyencodablesection not returning updated string

### DIFF
--- a/modules/cmpapi/src/encoder/GppModel.ts
+++ b/modules/cmpapi/src/encoder/GppModel.ts
@@ -111,6 +111,7 @@ export class GppModel {
     if (section) {
       section.setFieldValue(fieldName, value);
       this.dirty = true;
+      section.setIsDirty(true);
     } else {
       throw new InvalidFieldError(sectionName + "." + fieldName + " not found");
     }

--- a/modules/cmpapi/src/encoder/section/AbstractLazilyEncodableSection.ts
+++ b/modules/cmpapi/src/encoder/section/AbstractLazilyEncodableSection.ts
@@ -105,4 +105,8 @@ export abstract class AbstractLazilyEncodableSection implements EncodableSection
     this.dirty = false;
     this.decoded = false;
   }
+
+  public setIsDirty(status: boolean): void {
+    this.dirty = status;
+  }
 }

--- a/modules/cmpapi/src/encoder/section/EncodableSection.ts
+++ b/modules/cmpapi/src/encoder/section/EncodableSection.ts
@@ -14,4 +14,6 @@ export interface EncodableSection {
   encode(): string;
 
   decode(encodedString: string): void;
+
+  setIsDirty(status: boolean): void;
 }


### PR DESCRIPTION
encode method in abstractlazilyencodablesection is not returning updated gpp string as dirty was set to false always