### PR TITLE
Fix string/section mismatch when decoding gpp string

### DIFF
--- a/modules/cmpapi/build
+++ b/modules/cmpapi/build
@@ -9,6 +9,7 @@ FILES=$(find lib/cjs -name "*.js")
 
 for FILE in $FILES; do
 
+  echo "Minifying $FILE"
   npx terser $FILE --ecma 5 -m -c -o $FILE
 
 done

--- a/modules/cmpapi/src/encoder/section/AbstractLazilyEncodableSection.ts
+++ b/modules/cmpapi/src/encoder/section/AbstractLazilyEncodableSection.ts
@@ -102,6 +102,7 @@ export abstract class AbstractLazilyEncodableSection implements EncodableSection
 
   public decode(encodedString: string): void {
     this.encodedString = encodedString;
+    this.segments = this.decodeSection(this.encodedString);
     this.dirty = false;
     this.decoded = false;
   }


### PR DESCRIPTION
Closes #79

When the `cmpapi.setSectionString()` method is called it was not updating the segments to match the decoded string, causing the string and section data to be mismatched.

This change includes the segments update for when the encode() method subsequently runs, ensuring they continue to be in sync.

To validate this fix:

```
import { CmpApi, TcfEuV2 } from "@iabgpp/cmpapi";

...
cmpApi.setSectionString(TcfEuV2.NAME, "CQM0UsAQM0UsAGXABBENBdFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAAAA");

cmpApi.fireSectionChange(TcfEuV2.NAME);

console.log(cmpApi.getGppString());
// correctly returns DBABMA~CQM0UsAQM0UsAGXABBENBdFgALAAAENAAAAAFyQAQFyAXJABAXIAAAAA

const sections = cmpApi.getObject();
console.log(sections[TcfEuV2.NAME].PurposeConsents);
// correctly returns [true, false, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false]
```

NOTE: I also included a bit of helpful output during the build process to show what it's working on.