### PR TITLE
Update VERSION for UsNat encoded strings, add tests for decoding version 1 strings

### DIFF
--- a/modules/cmpapi/src/encoder/section/UsNat.ts
+++ b/modules/cmpapi/src/encoder/section/UsNat.ts
@@ -6,7 +6,7 @@ import { UsNatGpcSegment } from "../segment/UsNatGpcSegment.js";
 
 export class UsNat extends AbstractLazilyEncodableSection {
   public static readonly ID = 7;
-  public static readonly VERSION = 1;
+  public static readonly VERSION = 2;
   public static readonly NAME = "usnat";
 
   constructor(encodedString?: string) {

--- a/modules/cmpapi/test/encoder/section/UsNat.test.ts
+++ b/modules/cmpapi/test/encoder/section/UsNat.test.ts
@@ -3,12 +3,12 @@ import { UsNatField } from "../../../src/encoder/field/UsNatField";
 import { UsNat } from "../../../src/encoder/section/UsNat";
 
 describe("manifest.section.UsNat", (): void => {
-  it("should encode default to BAAAAAAAAABA.QA", (): void => {
+  it("should encode default to CAAAAAAAAABA.QA", (): void => {
     let usNat = new UsNat();
-    expect(usNat.encode()).to.eql("BAAAAAAAAABA.QA");
+    expect(usNat.encode()).to.eql("CAAAAAAAAABA.QA");
   });
 
-  it("should encode to BVVVkkkkkpFY.YA", (): void => {
+  it("should encode to CVVVkkkkkpFY.YA", (): void => {
     let usNat = new UsNat();
 
     usNat.setFieldValue(UsNatField.SHARING_NOTICE, 1);
@@ -28,13 +28,13 @@ describe("manifest.section.UsNat", (): void => {
     usNat.setFieldValue(UsNatField.MSPA_SERVICE_PROVIDER_MODE, 2);
     usNat.setFieldValue(UsNatField.GPC, true);
 
-    expect(usNat.encode()).to.eql("BVVVkkkkkpFY.YA");
+    expect(usNat.encode()).to.eql("CVVVkkkkkpFY.YA");
   });
 
-  it("should encode default to BAAAAAAAAABA", (): void => {
+  it("should encode default to CAAAAAAAAABA", (): void => {
     let usNat = new UsNat();
     usNat.setFieldValue(UsNatField.GPC_SEGMENT_INCLUDED, false);
-    expect(usNat.encode()).to.eql("BAAAAAAAAABA");
+    expect(usNat.encode()).to.eql("CAAAAAAAAABA");
   });
 
   it("should throw an error if invalid values are set", (): void => {
@@ -101,47 +101,96 @@ describe("manifest.section.UsNat", (): void => {
     }).to.throw();
   });
 
-  it("should decode BVVVkkkkkpFY.YA", (): void => {
-    let usNat = new UsNat("BVVVkkkkkpFY.YA");
+  it("should decode BVVVkkkklWA.YA", (): void => {
+    let usNat = new UsNat("BVVVkkkklWA.YA");
 
-    expect(1, usNat.getFieldValue(UsNatField.SHARING_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SALE_OPT_OUT_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SHARING_OPT_OUT_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING_OPT_OUT_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SENSITIVE_DATA_LIMIT_USE_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SALE_OPT_OUT));
-    expect(1, usNat.getFieldValue(UsNatField.SHARING_OPT_OUT));
-    expect(1, usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT));
-    expect([2, 1, 0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2], usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING));
-    expect([2, 1, 0], usNat.getFieldValue(UsNatField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS));
-    expect(1, usNat.getFieldValue(UsNatField.PERSONAL_DATA_CONSENTS));
-    expect(1, usNat.getFieldValue(UsNatField.MSPA_COVERED_TRANSACTION));
-    expect(1, usNat.getFieldValue(UsNatField.MSPA_OPT_OUT_OPTION_MODE));
-    expect(2, usNat.getFieldValue(UsNatField.MSPA_SERVICE_PROVIDER_MODE));
-    expect(true, usNat.getFieldValue(UsNatField.GPC));
-    expect(true, usNat.getFieldValue(UsNatField.GPC_SEGMENT_INCLUDED));
+    expect(usNat.getFieldValue(UsNatField.VERSION)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SHARING_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SALE_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SHARING_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_LIMIT_USE_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SALE_OPT_OUT)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SHARING_OPT_OUT)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING)).to.eql([2, 1, 0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 0, 0, 0, 0]);
+    expect(usNat.getFieldValue(UsNatField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS)).to.eql([2, 1, 0]);
+    expect(usNat.getFieldValue(UsNatField.PERSONAL_DATA_CONSENTS)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.MSPA_COVERED_TRANSACTION)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.MSPA_OPT_OUT_OPTION_MODE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.MSPA_SERVICE_PROVIDER_MODE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.GPC)).to.eql(true);
+    expect(usNat.getFieldValue(UsNatField.GPC_SEGMENT_INCLUDED)).to.eql(true);
   });
 
-  it("should decode BVVVkkkkkpFY.YA", (): void => {
-    let usNat = new UsNat("BVVVkkkkkpFY");
+  it("should decode BqqqqqqqqqA", (): void => {
+    let usNat = new UsNat("BqqqqqqqqqA");
 
-    expect(1, usNat.getFieldValue(UsNatField.SHARING_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SALE_OPT_OUT_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SHARING_OPT_OUT_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING_OPT_OUT_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SENSITIVE_DATA_LIMIT_USE_NOTICE));
-    expect(1, usNat.getFieldValue(UsNatField.SALE_OPT_OUT));
-    expect(1, usNat.getFieldValue(UsNatField.SHARING_OPT_OUT));
-    expect(1, usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT));
-    expect([2, 1, 0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2], usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING));
-    expect([2, 1, 0], usNat.getFieldValue(UsNatField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS));
-    expect(1, usNat.getFieldValue(UsNatField.PERSONAL_DATA_CONSENTS));
-    expect(1, usNat.getFieldValue(UsNatField.MSPA_COVERED_TRANSACTION));
-    expect(1, usNat.getFieldValue(UsNatField.MSPA_OPT_OUT_OPTION_MODE));
-    expect(2, usNat.getFieldValue(UsNatField.MSPA_SERVICE_PROVIDER_MODE));
-    expect(false, usNat.getFieldValue(UsNatField.GPC_SEGMENT_INCLUDED));
+    expect(usNat.getFieldValue(UsNatField.VERSION)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SHARING_NOTICE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.SALE_OPT_OUT_NOTICE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.SHARING_OPT_OUT_NOTICE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT_NOTICE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING_OPT_OUT_NOTICE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_LIMIT_USE_NOTICE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.SALE_OPT_OUT)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.SHARING_OPT_OUT)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING)).to.eql([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0]);
+    expect(usNat.getFieldValue(UsNatField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS)).to.eql([2, 2, 0]);
+    expect(usNat.getFieldValue(UsNatField.PERSONAL_DATA_CONSENTS)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.MSPA_COVERED_TRANSACTION)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.MSPA_OPT_OUT_OPTION_MODE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.MSPA_SERVICE_PROVIDER_MODE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.GPC_SEGMENT_INCLUDED)).to.eql(false);
+    expect(usNat.getFieldValue(UsNatField.GPC)).to.eql(false);
+  });
+
+  it("should decode CVVVkkkkkpFY.YA", (): void => {
+    let usNat = new UsNat("CVVVkkkkkpFY.YA");
+
+    expect(usNat.getFieldValue(UsNatField.VERSION)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.SHARING_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SALE_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SHARING_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_LIMIT_USE_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SALE_OPT_OUT)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SHARING_OPT_OUT)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING)).to.eql([2, 1, 0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2]);
+    expect(usNat.getFieldValue(UsNatField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS)).to.eql([2, 1, 0]);
+    expect(usNat.getFieldValue(UsNatField.PERSONAL_DATA_CONSENTS)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.MSPA_COVERED_TRANSACTION)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.MSPA_OPT_OUT_OPTION_MODE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.MSPA_SERVICE_PROVIDER_MODE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.GPC)).to.eql(true);
+    expect(usNat.getFieldValue(UsNatField.GPC_SEGMENT_INCLUDED)).to.eql(true);
+  });
+
+  it("should decode CVVVkkkkkpFY", (): void => {
+    let usNat = new UsNat("CVVVkkkkkpFY");
+
+    expect(usNat.getFieldValue(UsNatField.VERSION)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.SHARING_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SALE_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SHARING_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING_OPT_OUT_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_LIMIT_USE_NOTICE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SALE_OPT_OUT)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SHARING_OPT_OUT)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.TARGETED_ADVERTISING_OPT_OUT)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.SENSITIVE_DATA_PROCESSING)).to.eql([2, 1, 0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2, 1, 0, 2]);
+    expect(usNat.getFieldValue(UsNatField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS)).to.eql([2, 1, 0]);
+    expect(usNat.getFieldValue(UsNatField.PERSONAL_DATA_CONSENTS)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.MSPA_COVERED_TRANSACTION)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.MSPA_OPT_OUT_OPTION_MODE)).to.eql(1);
+    expect(usNat.getFieldValue(UsNatField.MSPA_SERVICE_PROVIDER_MODE)).to.eql(2);
+    expect(usNat.getFieldValue(UsNatField.GPC_SEGMENT_INCLUDED)).to.eql(false);
+    expect(usNat.getFieldValue(UsNatField.GPC)).to.eql(false);
   });
 
   it("should throw Error on garbage", (): void => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iabgpp",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iabgpp",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "license": "Apache-2.0",
       "workspaces": [
         "modules/stub",
@@ -15,7 +15,7 @@
     },
     "modules/cmpapi": {
       "name": "@iabgpp/cmpapi",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^28.1.6",
@@ -47,7 +47,7 @@
     },
     "modules/stub": {
       "name": "@iabgpp/stub",
-      "version": "3.1.6",
+      "version": "3.1.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/cli": "^7.18.6",


### PR DESCRIPTION
Possibly related issues
- https://github.com/IABTechLab/iabgpp-es/issues/90
- https://github.com/IABTechLab/iabgpp-es/issues/84
- https://github.com/IABTechLab/iabgpp-es/issues/81
- https://github.com/IABTechLab/iabgpp-es/issues/75

### Problem
GPP strings encoded with the UsNat section are being encoded not in accordance to the spec.

Version 1 UsNat section should have 12 values for SensitiveDataProcessing and 2 values for KnownChildSensitiveDataConsents. https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/us-va_1.0/Sections/US-National/IAB%20Privacy%E2%80%99s%20National%20Privacy%20Technical%20Specification.md

Version 2 UsNat section has 16 values for SensitiveDataProcessing and 3 values for KnownChildSensitiveDataConsents

The support for the extra values was added in #67 [UsNatCoreSegment.ts](https://github.com/IABTechLab/iabgpp-es/commit/9a4a7fd16e68ce0dd259a54fed80407b70f36260#diff-4200c161641fdfd9f4669e2edd164388654dcb582d43d7980c26be68f3f9c8e8), but the VERSION constant was not updated. This means that the UsNat consent strings are being encoded as Version 1 but having 16 and 3 values for SensitiveDataProcessing and KnownChildSensitiveDataConsents

### Adjustments
1. Adjust the VERSION for UsNat, since this always encodes a Version 2 string.
2. Add tests for parsing Version 1 strings to demonstrate they do get added 0s for the two expanded fields.
3. Update UsNat tests to adjust the syntax. The tests as written were not actually working for me; I could adjust them in place and they would never fail.

### Open Question
When parsing a Version 1 string, should the Version be updated to Version 2 in the internal storage? If a Version 1 string is decoded and then encoded, the result will be a Version 2 string. I think this would mainly help with confusion, to avoid the object indicating it is Version 1 while having expanded field values; even if they were padded with 0s for the additional options.

The `package-lock.json` updated when running `npm install`, so I included it.