### PR TITLE
Add UsMd section (Maryland, Section ID 24)

### DIFF
--- a/modules/cmpapi/src/encoder/GppModel.ts
+++ b/modules/cmpapi/src/encoder/GppModel.ts
@@ -24,6 +24,7 @@ import { UsNh } from "./section/UsNh.js";
 import { UsNj } from "./section/UsNj.js";
 import { UsTn } from "./section/UsTn.js";
 import { UsMn } from "./section/UsMn.js";
+import { UsMd } from "./section/UsMd.js";
 
 export class GppModel {
   private sections = new Map<string, EncodableSection>();
@@ -107,6 +108,9 @@ export class GppModel {
       } else if (sectionName === UsMn.NAME) {
         section = new UsMn();
         this.sections.set(UsMn.NAME, section);
+      } else if (sectionName === UsMd.NAME) {
+        section = new UsMd();
+        this.sections.set(UsMd.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);
@@ -342,6 +346,9 @@ export class GppModel {
           } else if (sectionIds[i] === UsMn.ID) {
             let section = new UsMn(encodedSections[i + 1]);
             sections.set(UsMn.NAME, section);
+          } else if (sectionIds[i] === UsMd.ID) {
+            let section = new UsMd(encodedSections[i + 1]);
+            sections.set(UsMd.NAME, section);
           }
         }
       }
@@ -450,6 +457,9 @@ export class GppModel {
       } else if (sectionName === UsMn.NAME) {
         section = new UsMn();
         this.sections.set(UsMn.NAME, section);
+      } else if (sectionName === UsMd.NAME) {
+        section = new UsMd();
+        this.sections.set(UsMd.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);

--- a/modules/cmpapi/src/encoder/field/UsMdField.ts
+++ b/modules/cmpapi/src/encoder/field/UsMdField.ts
@@ -1,0 +1,29 @@
+export enum UsMdField {
+  MSPA_VERSION = "MspaVersion",
+  MSPA_COVERED_TRANSACTION = "MspaCoveredTransaction",
+  MSPA_MODE = "MspaMode",
+  PROCESSING_NOTICE = "ProcessingNotice",
+  SALE_OPT_OUT_NOTICE = "SaleOptOutNotice",
+  TARGETED_ADVERTISING_OPT_OUT_NOTICE = "TargetedAdvertisingOptOutNotice",
+  SALE_OPT_OUT = "SaleOptOut",
+  TARGETED_ADVERTISING_OPT_OUT = "TargetedAdvertisingOptOut",
+  ADDITIONAL_DATA_PROCESSING_CONSENT = "AdditionalDataProcessingConsent",
+
+  GPC_SEGMENT_TYPE = "GpcSegmentType",
+  GPC_SEGMENT_INCLUDED = "GpcSegmentIncluded",
+  GPC = "Gpc",
+}
+
+export const UsMd_CORE_SEGMENT_FIELD_NAMES = [
+  UsMdField.MSPA_VERSION,
+  UsMdField.MSPA_COVERED_TRANSACTION,
+  UsMdField.MSPA_MODE,
+  UsMdField.PROCESSING_NOTICE,
+  UsMdField.SALE_OPT_OUT_NOTICE,
+  UsMdField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+  UsMdField.SALE_OPT_OUT,
+  UsMdField.TARGETED_ADVERTISING_OPT_OUT,
+  UsMdField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+];
+
+export const UsMd_GPC_SEGMENT_FIELD_NAMES = [UsMdField.GPC_SEGMENT_TYPE, UsMdField.GPC];

--- a/modules/cmpapi/src/encoder/field/index.ts
+++ b/modules/cmpapi/src/encoder/field/index.ts
@@ -10,6 +10,7 @@ export * from "./UsCtField.js";
 export * from "./UsDeField.js";
 export * from "./UsFlField.js";
 export * from "./UsIaField.js";
+export * from "./UsMdField.js";
 export * from "./UsMnField.js";
 export * from "./UsMtField.js";
 export * from "./UsNatField.js";

--- a/modules/cmpapi/src/encoder/section/Sections.ts
+++ b/modules/cmpapi/src/encoder/section/Sections.ts
@@ -18,6 +18,7 @@ import { UsNh } from "./UsNh.js";
 import { UsNj } from "./UsNj.js";
 import { UsTn } from "./UsTn.js";
 import { UsMn } from "./UsMn.js";
+import { UsMd } from "./UsMd.js";
 
 export class Sections {
   public static SECTION_ID_NAME_MAP = new Map([
@@ -41,6 +42,7 @@ export class Sections {
     [UsNj.ID, UsNj.NAME],
     [UsTn.ID, UsTn.NAME],
     [UsMn.ID, UsMn.NAME],
+    [UsMd.ID, UsMd.NAME],
   ]);
   public static SECTION_ORDER = [
     TcfEuV2.NAME,
@@ -62,6 +64,7 @@ export class Sections {
     UsNh.NAME,
     UsNj.NAME,
     UsTn.NAME,
-    UsMn.NAME
+    UsMn.NAME,
+    UsMd.NAME
   ];
 }

--- a/modules/cmpapi/src/encoder/section/UsMd.ts
+++ b/modules/cmpapi/src/encoder/section/UsMd.ts
@@ -1,0 +1,77 @@
+import { UsMdField } from "../field/UsMdField.js";
+import { EncodableSegment } from "../segment/EncodableSegment.js";
+import { UsMdCoreSegment } from "../segment/UsMdCoreSegment.js";
+import { UsMdGpcSegment } from "../segment/UsMdGpcSegment.js";
+import { AbstractLazilyEncodableSection } from "./AbstractLazilyEncodableSection.js";
+
+export class UsMd extends AbstractLazilyEncodableSection {
+  public static readonly ID = 24;
+  public static readonly VERSION = 1;
+  public static readonly NAME = "usmd";
+
+  constructor(encodedString?: string) {
+    super();
+    if (encodedString && encodedString.length > 0) {
+      this.decode(encodedString);
+    }
+  }
+
+  //Overriden
+  public getId(): number {
+    return UsMd.ID;
+  }
+
+  //Overriden
+  public getName(): string {
+    return UsMd.NAME;
+  }
+
+  //Override
+  public getVersion(): number {
+    return UsMd.VERSION;
+  }
+
+  //Overriden
+  protected initializeSegments(): EncodableSegment[] {
+    let segments: EncodableSegment[] = [];
+    segments.push(new UsMdCoreSegment());
+    segments.push(new UsMdGpcSegment());
+    return segments;
+  }
+
+  //Overriden
+  protected decodeSection(encodedString: string): EncodableSegment[] {
+    let segments: EncodableSegment[] = this.initializeSegments();
+
+    if (encodedString != null && encodedString.length !== 0) {
+      let encodedSegments = encodedString.split(".");
+
+      if (encodedSegments.length > 0) {
+        segments[0].decode(encodedSegments[0]);
+      }
+
+      if (encodedSegments.length > 1) {
+        segments[1].setFieldValue(UsMdField.GPC_SEGMENT_INCLUDED, true);
+        segments[1].decode(encodedSegments[1]);
+      } else {
+        segments[1].setFieldValue(UsMdField.GPC_SEGMENT_INCLUDED, false);
+      }
+    }
+
+    return segments;
+  }
+
+  // Overriden
+  protected encodeSection(segments: EncodableSegment[]): string {
+    let encodedSegments: string[] = [];
+
+    if (segments.length >= 1) {
+      encodedSegments.push(segments[0].encode());
+      if (segments.length >= 2 && segments[1].getFieldValue(UsMdField.GPC_SEGMENT_INCLUDED) === true) {
+        encodedSegments.push(segments[1].encode());
+      }
+    }
+
+    return encodedSegments.join(".");
+  }
+}

--- a/modules/cmpapi/src/encoder/section/index.ts
+++ b/modules/cmpapi/src/encoder/section/index.ts
@@ -10,6 +10,7 @@ export * from "./UsCt.js";
 export * from "./UsDe.js";
 export * from "./UsFl.js";
 export * from "./UsIa.js";
+export * from "./UsMd.js";
 export * from "./UsMn.js";
 export * from "./UsMt.js";
 export * from "./UsNat.js";

--- a/modules/cmpapi/src/encoder/segment/UsMdCoreSegment.ts
+++ b/modules/cmpapi/src/encoder/segment/UsMdCoreSegment.ts
@@ -1,0 +1,99 @@
+import { AbstractBase64UrlEncoder } from "../base64/AbstractBase64UrlEncoder.js";
+import { CompressedBase64UrlEncoder } from "../base64/CompressedBase64UrlEncoder.js";
+import { BitStringEncoder } from "../bitstring/BitStringEncoder.js";
+import { EncodableFixedInteger } from "../datatype/EncodableFixedInteger.js";
+import { Predicate } from "../datatype/validate/Predicate.js";
+import { DecodingError } from "../error/DecodingError.js";
+import { EncodableBitStringFields } from "../field/EncodableBitStringFields.js";
+import { UsMd_CORE_SEGMENT_FIELD_NAMES } from "../field/UsMdField.js";
+import { UsMdField } from "../field/UsMdField.js";
+import { UsMd } from "../section/UsMd.js";
+import { AbstractLazilyEncodableSegment } from "./AbstractLazilyEncodableSegment.js";
+
+export class UsMdCoreSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+  private base64UrlEncoder: AbstractBase64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private bitStringEncoder: BitStringEncoder = BitStringEncoder.getInstance();
+
+  constructor(encodedString?: string) {
+    super();
+    if (encodedString) {
+      this.decode(encodedString);
+    }
+  }
+
+  // overriden
+  public getFieldNames(): string[] {
+    return UsMd_CORE_SEGMENT_FIELD_NAMES;
+  }
+
+  // overriden
+  protected initializeFields(): EncodableBitStringFields {
+    const nullableBooleanAsTwoBitIntegerValidator = new (class implements Predicate<number> {
+      test(n: number): boolean {
+        return n >= 0 && n <= 2;
+      }
+    })();
+
+    const nonNullableBooleanAsTwoBitIntegerValidator = new (class implements Predicate<number> {
+      test(n: number): boolean {
+        return n >= 1 && n <= 2;
+      }
+    })();
+
+    let fields: EncodableBitStringFields = new EncodableBitStringFields();
+    fields.put(UsMdField.MSPA_VERSION.toString(), new EncodableFixedInteger(6, UsMd.VERSION));
+    fields.put(
+      UsMdField.MSPA_COVERED_TRANSACTION.toString(),
+      new EncodableFixedInteger(2, 1).withValidator(nonNullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsMdField.MSPA_MODE.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsMdField.PROCESSING_NOTICE.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsMdField.SALE_OPT_OUT_NOTICE.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsMdField.TARGETED_ADVERTISING_OPT_OUT_NOTICE.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsMdField.SALE_OPT_OUT.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsMdField.TARGETED_ADVERTISING_OPT_OUT.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsMdField.ADDITIONAL_DATA_PROCESSING_CONSENT.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    return fields;
+  }
+
+  // overriden
+  protected encodeSegment(fields: EncodableBitStringFields): string {
+    let bitString: string = this.bitStringEncoder.encode(fields, this.getFieldNames());
+    let encodedString: string = this.base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  // overriden
+  protected decodeSegment(encodedString: string, fields: EncodableBitStringFields): void {
+    if (encodedString == null || encodedString.length === 0) {
+      this.fields.reset(fields);
+    }
+    try {
+      let bitString: string = this.base64UrlEncoder.decode(encodedString);
+      this.bitStringEncoder.decode(bitString, this.getFieldNames(), fields);
+    } catch (e) {
+      throw new DecodingError("Unable to decode UsMdCoreSegment '" + encodedString + "'");
+    }
+  }
+}

--- a/modules/cmpapi/src/encoder/segment/UsMdGpcSegment.ts
+++ b/modules/cmpapi/src/encoder/segment/UsMdGpcSegment.ts
@@ -1,0 +1,56 @@
+import { AbstractBase64UrlEncoder } from "../base64/AbstractBase64UrlEncoder.js";
+import { CompressedBase64UrlEncoder } from "../base64/CompressedBase64UrlEncoder.js";
+import { BitStringEncoder } from "../bitstring/BitStringEncoder.js";
+import { EncodableBoolean } from "../datatype/EncodableBoolean.js";
+import { EncodableFixedInteger } from "../datatype/EncodableFixedInteger.js";
+import { DecodingError } from "../error/DecodingError.js";
+import { EncodableBitStringFields } from "../field/EncodableBitStringFields.js";
+import { UsMd_GPC_SEGMENT_FIELD_NAMES } from "../field/UsMdField.js";
+import { UsMdField } from "../field/UsMdField.js";
+import { AbstractLazilyEncodableSegment } from "./AbstractLazilyEncodableSegment.js";
+
+export class UsMdGpcSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+  private base64UrlEncoder: AbstractBase64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private bitStringEncoder: BitStringEncoder = BitStringEncoder.getInstance();
+
+  constructor(encodedString?: string) {
+    super();
+    if (encodedString) {
+      this.decode(encodedString);
+    }
+  }
+
+  // overriden
+  public getFieldNames(): string[] {
+    return UsMd_GPC_SEGMENT_FIELD_NAMES;
+  }
+
+  // overriden
+  protected initializeFields(): EncodableBitStringFields {
+    let fields: EncodableBitStringFields = new EncodableBitStringFields();
+    fields.put(UsMdField.GPC_SEGMENT_TYPE.toString(), new EncodableFixedInteger(2, 1));
+    fields.put(UsMdField.GPC_SEGMENT_INCLUDED.toString(), new EncodableBoolean(true));
+    fields.put(UsMdField.GPC.toString(), new EncodableBoolean(false));
+    return fields;
+  }
+
+  // overriden
+  protected encodeSegment(fields: EncodableBitStringFields): string {
+    let bitString: string = this.bitStringEncoder.encode(fields, this.getFieldNames());
+    let encodedString: string = this.base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  // overriden
+  protected decodeSegment(encodedString: string, fields: EncodableBitStringFields): void {
+    if (encodedString == null || encodedString.length === 0) {
+      this.fields.reset(fields);
+    }
+    try {
+      let bitString: string = this.base64UrlEncoder.decode(encodedString);
+      this.bitStringEncoder.decode(bitString, this.getFieldNames(), fields);
+    } catch (e) {
+      throw new DecodingError("Unable to decode UsMdGpcSegment '" + encodedString + "'");
+    }
+  }
+}

--- a/modules/cmpapi/src/encoder/segment/index.ts
+++ b/modules/cmpapi/src/encoder/segment/index.ts
@@ -19,6 +19,8 @@ export * from "./UsDeGpcSegment.js";
 export * from "./UsFlCoreSegment.js";
 export * from "./UsIaCoreSegment.js";
 export * from "./UsIaGpcSegment.js";
+export * from "./UsMdCoreSegment.js";
+export * from "./UsMdGpcSegment.js";
 export * from "./UsNatCoreSegment.js";
 export * from "./UsNeCoreSegment.js";
 export * from "./UsNeGpcSegment.js";

--- a/modules/cmpapi/test/GppModel.test.ts
+++ b/modules/cmpapi/test/GppModel.test.ts
@@ -60,6 +60,7 @@ describe("manifest.GppModel", (): void => {
     expect(gppModel.hasSection("usnj")).to.eql(false);
     expect(gppModel.hasSection("ustn")).to.eql(false);
     expect(gppModel.hasSection("usmn")).to.eql(false);
+    expect(gppModel.hasSection("usmd")).to.eql(false);
 
     gppModel.setFieldValue("tcfeuv2", "Version", 2);
     gppModel.setFieldValue("tcfeuv2", "CmpId", 880);
@@ -86,6 +87,7 @@ describe("manifest.GppModel", (): void => {
     gppModel.setFieldValue("usnj", "Version", 1);
     gppModel.setFieldValue("ustn", "Version", 1);
     gppModel.setFieldValue("usmn", "Version", 1);
+    gppModel.setFieldValue("usmd", "MspaVersion", 1);
 
     expect(gppModel.hasSection("tcfeuv2")).to.eql(true);
     expect(gppModel.hasSection("tcfcav1")).to.eql(true);
@@ -107,10 +109,11 @@ describe("manifest.GppModel", (): void => {
     expect(gppModel.hasSection("usnj")).to.eql(true);
     expect(gppModel.hasSection("ustn")).to.eql(true);
     expect(gppModel.hasSection("usmn")).to.eql(true);
+    expect(gppModel.hasSection("usmd")).to.eql(true);
 
     let gppString = gppModel.encode();
     expect(gppString).to.eql(
-      "DBACOYs~CPSG_8APSG_8ANwAAAENAAFgAAAAAAAAAAAAAAAAAAAA.IAAA.YAAAAAAAAAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA"
+      "DBACOcs~CPSG_8APSG_8ANwAAAENAAFgAAAAAAAAAAAAAAAAAAAA.IAAA.YAAAAAAAAAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAA.QA"
     );
   });
 
@@ -411,7 +414,7 @@ describe("manifest.GppModel", (): void => {
 
   it("should decode defaults from all sections", (): void => {
     let gppString =
-      "DBACOYs~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA";
+      "DBACOcs~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAA.QA";
     let gppModel = new GppModel(gppString);
 
     expect(gppModel.hasSection("tcfeuv2")).to.eql(true);
@@ -434,6 +437,7 @@ describe("manifest.GppModel", (): void => {
     expect(gppModel.hasSection("usnj")).to.eql(true);
     expect(gppModel.hasSection("ustn")).to.eql(true);
     expect(gppModel.hasSection("usmn")).to.eql(true);
+    expect(gppModel.hasSection("usmd")).to.eql(true);
   });
 
   it("should decode uspv1 section", (): void => {

--- a/modules/cmpapi/test/encoder/section/UsMd.test.ts
+++ b/modules/cmpapi/test/encoder/section/UsMd.test.ts
@@ -1,0 +1,63 @@
+import { expect } from "chai";
+import { UsMdField } from "../../../src/encoder/field/UsMdField";
+import { UsMd } from "../../../src/encoder/section/UsMd";
+
+describe("manifest.section.UsMd", (): void => {
+  it("should encode default", (): void => {
+    let usMd = new UsMd();
+    expect(usMd.encode()).to.eql("BQAA.Q");
+  });
+
+  it("should encode with all fields set", (): void => {
+    let usMd = new UsMd();
+
+    usMd.setFieldValue(UsMdField.MSPA_COVERED_TRANSACTION, 1);
+    usMd.setFieldValue(UsMdField.MSPA_MODE, 1);
+    usMd.setFieldValue(UsMdField.PROCESSING_NOTICE, 1);
+    usMd.setFieldValue(UsMdField.SALE_OPT_OUT_NOTICE, 1);
+    usMd.setFieldValue(UsMdField.TARGETED_ADVERTISING_OPT_OUT_NOTICE, 1);
+    usMd.setFieldValue(UsMdField.SALE_OPT_OUT, 1);
+    usMd.setFieldValue(UsMdField.TARGETED_ADVERTISING_OPT_OUT, 1);
+    usMd.setFieldValue(UsMdField.ADDITIONAL_DATA_PROCESSING_CONSENT, 1);
+    usMd.setFieldValue(UsMdField.GPC, true);
+
+    expect(usMd.encode()).to.eql("BVVV.Y");
+  });
+
+  it("should encode default with gpc segment excluded", (): void => {
+    let usMd = new UsMd();
+    usMd.setFieldValue(UsMdField.GPC_SEGMENT_INCLUDED, false);
+    expect(usMd.encode()).to.eql("BQAA");
+  });
+
+  it("should throw an error if invalid values are set", (): void => {
+    let usMd = new UsMd();
+
+    expect(function () {
+      usMd.setFieldValue(UsMdField.MSPA_COVERED_TRANSACTION, 0);
+    }).to.throw();
+
+    expect(function () {
+      usMd.setFieldValue(UsMdField.MSPA_MODE, 3);
+    }).to.throw();
+
+    expect(function () {
+      usMd.setFieldValue(UsMdField.PROCESSING_NOTICE, 3);
+    }).to.throw();
+  });
+
+  it("should decode", (): void => {
+    let usMd = new UsMd("BVVV.Y");
+
+    expect(usMd.getFieldValue(UsMdField.MSPA_COVERED_TRANSACTION)).to.eql(1);
+    expect(usMd.getFieldValue(UsMdField.MSPA_MODE)).to.eql(1);
+    expect(usMd.getFieldValue(UsMdField.PROCESSING_NOTICE)).to.eql(1);
+    expect(usMd.getFieldValue(UsMdField.GPC)).to.eql(true);
+  });
+
+  it("should throw Error on garbage", (): void => {
+    expect(function () {
+      new UsMd("z").getFieldValue(UsMdField.PROCESSING_NOTICE);
+    }).to.throw("Unable to decode UsMdCoreSegment 'z'");
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Maryland section per the GPP US-States/MD spec, registered as Section ID 24 (client-side API prefix `usmd`).

- Adds `UsMd` section, `UsMdField` enum, `UsMdCoreSegment`, `UsMdGpcSegment` following the existing `UsMn` pattern.
- Registers the section in `Sections.ts`, `GppModel.ts`, and all three (`field`/`section`/`segment`) `index.ts` re-exports.
- Per the Maryland spec, the core subsection has 9 fields and omits `SensitiveDataProcessing` and `KnownChildSensitiveDataConsents`. The single `MspaMode` field replaces `MspaOptOutOptionMode` + `MspaServiceProviderMode`, and `MspaVersion` is the first field.

## Test plan

- [x] Added `UsMd.test.ts` covering encode default, encode all fields, GPC-segment exclusion, validation rejection, round-trip decode, and garbage input
- [x] Updated `GppModel.test.ts` "should default all sections" and "should decode defaults from all sections" to include UsMd
- [x] `npm test` on `modules/cmpapi`: **336 passing**