### PR TITLE
Add UsRi section (Rhode Island, Section ID 27)

### DIFF
--- a/modules/cmpapi/src/encoder/GppModel.ts
+++ b/modules/cmpapi/src/encoder/GppModel.ts
@@ -24,6 +24,7 @@ import { UsNh } from "./section/UsNh.js";
 import { UsNj } from "./section/UsNj.js";
 import { UsTn } from "./section/UsTn.js";
 import { UsMn } from "./section/UsMn.js";
+import { UsRi } from "./section/UsRi.js";
 
 export class GppModel {
   private sections = new Map<string, EncodableSection>();
@@ -107,6 +108,9 @@ export class GppModel {
       } else if (sectionName === UsMn.NAME) {
         section = new UsMn();
         this.sections.set(UsMn.NAME, section);
+      } else if (sectionName === UsRi.NAME) {
+        section = new UsRi();
+        this.sections.set(UsRi.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);
@@ -342,6 +346,9 @@ export class GppModel {
           } else if (sectionIds[i] === UsMn.ID) {
             let section = new UsMn(encodedSections[i + 1]);
             sections.set(UsMn.NAME, section);
+          } else if (sectionIds[i] === UsRi.ID) {
+            let section = new UsRi(encodedSections[i + 1]);
+            sections.set(UsRi.NAME, section);
           }
         }
       }
@@ -450,6 +457,9 @@ export class GppModel {
       } else if (sectionName === UsMn.NAME) {
         section = new UsMn();
         this.sections.set(UsMn.NAME, section);
+      } else if (sectionName === UsRi.NAME) {
+        section = new UsRi();
+        this.sections.set(UsRi.NAME, section);
       }
     } else {
       section = this.sections.get(sectionName);

--- a/modules/cmpapi/src/encoder/field/UsRiField.ts
+++ b/modules/cmpapi/src/encoder/field/UsRiField.ts
@@ -1,0 +1,33 @@
+export enum UsRiField {
+  MSPA_VERSION = "MspaVersion",
+  MSPA_COVERED_TRANSACTION = "MspaCoveredTransaction",
+  MSPA_MODE = "MspaMode",
+  PROCESSING_NOTICE = "ProcessingNotice",
+  SALE_OPT_OUT_NOTICE = "SaleOptOutNotice",
+  TARGETED_ADVERTISING_OPT_OUT_NOTICE = "TargetedAdvertisingOptOutNotice",
+  SALE_OPT_OUT = "SaleOptOut",
+  TARGETED_ADVERTISING_OPT_OUT = "TargetedAdvertisingOptOut",
+  KNOWN_CHILD_SENSITIVE_DATA_CONSENTS = "KnownChildSensitiveDataConsents",
+  ADDITIONAL_DATA_PROCESSING_CONSENT = "AdditionalDataProcessingConsent",
+  SENSITIVE_DATA_PROCESSING = "SensitiveDataProcessing",
+
+  GPC_SEGMENT_TYPE = "GpcSegmentType",
+  GPC_SEGMENT_INCLUDED = "GpcSegmentIncluded",
+  GPC = "Gpc",
+}
+
+export const UsRi_CORE_SEGMENT_FIELD_NAMES = [
+  UsRiField.MSPA_VERSION,
+  UsRiField.MSPA_COVERED_TRANSACTION,
+  UsRiField.MSPA_MODE,
+  UsRiField.PROCESSING_NOTICE,
+  UsRiField.SALE_OPT_OUT_NOTICE,
+  UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE,
+  UsRiField.SALE_OPT_OUT,
+  UsRiField.TARGETED_ADVERTISING_OPT_OUT,
+  UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS,
+  UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT,
+  UsRiField.SENSITIVE_DATA_PROCESSING,
+];
+
+export const UsRi_GPC_SEGMENT_FIELD_NAMES = [UsRiField.GPC_SEGMENT_TYPE, UsRiField.GPC];

--- a/modules/cmpapi/src/encoder/field/index.ts
+++ b/modules/cmpapi/src/encoder/field/index.ts
@@ -17,6 +17,7 @@ export * from "./UsNeField.js";
 export * from "./UsNhField.js";
 export * from "./UsNjField.js";
 export * from "./UsOrField.js";
+export * from "./UsRiField.js";
 export * from "./UsTnField.js";
 export * from "./UsTxField.js";
 export * from "./UsUtField.js";

--- a/modules/cmpapi/src/encoder/section/Sections.ts
+++ b/modules/cmpapi/src/encoder/section/Sections.ts
@@ -18,6 +18,7 @@ import { UsNh } from "./UsNh.js";
 import { UsNj } from "./UsNj.js";
 import { UsTn } from "./UsTn.js";
 import { UsMn } from "./UsMn.js";
+import { UsRi } from "./UsRi.js";
 
 export class Sections {
   public static SECTION_ID_NAME_MAP = new Map([
@@ -41,6 +42,7 @@ export class Sections {
     [UsNj.ID, UsNj.NAME],
     [UsTn.ID, UsTn.NAME],
     [UsMn.ID, UsMn.NAME],
+    [UsRi.ID, UsRi.NAME],
   ]);
   public static SECTION_ORDER = [
     TcfEuV2.NAME,
@@ -62,6 +64,7 @@ export class Sections {
     UsNh.NAME,
     UsNj.NAME,
     UsTn.NAME,
-    UsMn.NAME
+    UsMn.NAME,
+    UsRi.NAME
   ];
 }

--- a/modules/cmpapi/src/encoder/section/UsRi.ts
+++ b/modules/cmpapi/src/encoder/section/UsRi.ts
@@ -1,0 +1,77 @@
+import { UsRiField } from "../field/UsRiField.js";
+import { EncodableSegment } from "../segment/EncodableSegment.js";
+import { UsRiCoreSegment } from "../segment/UsRiCoreSegment.js";
+import { UsRiGpcSegment } from "../segment/UsRiGpcSegment.js";
+import { AbstractLazilyEncodableSection } from "./AbstractLazilyEncodableSection.js";
+
+export class UsRi extends AbstractLazilyEncodableSection {
+  public static readonly ID = 27;
+  public static readonly VERSION = 1;
+  public static readonly NAME = "usri";
+
+  constructor(encodedString?: string) {
+    super();
+    if (encodedString && encodedString.length > 0) {
+      this.decode(encodedString);
+    }
+  }
+
+  //Overriden
+  public getId(): number {
+    return UsRi.ID;
+  }
+
+  //Overriden
+  public getName(): string {
+    return UsRi.NAME;
+  }
+
+  //Override
+  public getVersion(): number {
+    return UsRi.VERSION;
+  }
+
+  //Overriden
+  protected initializeSegments(): EncodableSegment[] {
+    let segments: EncodableSegment[] = [];
+    segments.push(new UsRiCoreSegment());
+    segments.push(new UsRiGpcSegment());
+    return segments;
+  }
+
+  //Overriden
+  protected decodeSection(encodedString: string): EncodableSegment[] {
+    let segments: EncodableSegment[] = this.initializeSegments();
+
+    if (encodedString != null && encodedString.length !== 0) {
+      let encodedSegments = encodedString.split(".");
+
+      if (encodedSegments.length > 0) {
+        segments[0].decode(encodedSegments[0]);
+      }
+
+      if (encodedSegments.length > 1) {
+        segments[1].setFieldValue(UsRiField.GPC_SEGMENT_INCLUDED, true);
+        segments[1].decode(encodedSegments[1]);
+      } else {
+        segments[1].setFieldValue(UsRiField.GPC_SEGMENT_INCLUDED, false);
+      }
+    }
+
+    return segments;
+  }
+
+  // Overriden
+  protected encodeSection(segments: EncodableSegment[]): string {
+    let encodedSegments: string[] = [];
+
+    if (segments.length >= 1) {
+      encodedSegments.push(segments[0].encode());
+      if (segments.length >= 2 && segments[1].getFieldValue(UsRiField.GPC_SEGMENT_INCLUDED) === true) {
+        encodedSegments.push(segments[1].encode());
+      }
+    }
+
+    return encodedSegments.join(".");
+  }
+}

--- a/modules/cmpapi/src/encoder/section/index.ts
+++ b/modules/cmpapi/src/encoder/section/index.ts
@@ -17,6 +17,7 @@ export * from "./UsNe.js";
 export * from "./UsNh.js";
 export * from "./UsNj.js";
 export * from "./UsOr.js";
+export * from "./UsRi.js";
 export * from "./UsTn.js";
 export * from "./UsTx.js";
 export * from "./UsUt.js";

--- a/modules/cmpapi/src/encoder/segment/UsRiCoreSegment.ts
+++ b/modules/cmpapi/src/encoder/segment/UsRiCoreSegment.ts
@@ -1,0 +1,121 @@
+import { AbstractBase64UrlEncoder } from "../base64/AbstractBase64UrlEncoder.js";
+import { CompressedBase64UrlEncoder } from "../base64/CompressedBase64UrlEncoder.js";
+import { BitStringEncoder } from "../bitstring/BitStringEncoder.js";
+import { EncodableFixedInteger } from "../datatype/EncodableFixedInteger.js";
+import { EncodableFixedIntegerList } from "../datatype/EncodableFixedIntegerList.js";
+import { Predicate } from "../datatype/validate/Predicate.js";
+import { DecodingError } from "../error/DecodingError.js";
+import { EncodableBitStringFields } from "../field/EncodableBitStringFields.js";
+import { UsRi_CORE_SEGMENT_FIELD_NAMES } from "../field/UsRiField.js";
+import { UsRiField } from "../field/UsRiField.js";
+import { UsRi } from "../section/UsRi.js";
+import { AbstractLazilyEncodableSegment } from "./AbstractLazilyEncodableSegment.js";
+
+export class UsRiCoreSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+  private base64UrlEncoder: AbstractBase64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private bitStringEncoder: BitStringEncoder = BitStringEncoder.getInstance();
+
+  constructor(encodedString?: string) {
+    super();
+    if (encodedString) {
+      this.decode(encodedString);
+    }
+  }
+
+  // overriden
+  public getFieldNames(): string[] {
+    return UsRi_CORE_SEGMENT_FIELD_NAMES;
+  }
+
+  // overriden
+  protected initializeFields(): EncodableBitStringFields {
+    const nullableBooleanAsTwoBitIntegerValidator = new (class implements Predicate<number> {
+      test(n: number): boolean {
+        return n >= 0 && n <= 2;
+      }
+    })();
+
+    const nonNullableBooleanAsTwoBitIntegerValidator = new (class implements Predicate<number> {
+      test(n: number): boolean {
+        return n >= 1 && n <= 2;
+      }
+    })();
+    const nullableBooleanAsTwoBitIntegerListValidator = new (class implements Predicate<number[]> {
+      test(l: number[]): boolean {
+        for (let i = 0; i < l.length; i++) {
+          let n = l[i];
+          if (n < 0 || n > 2) {
+            return false;
+          }
+        }
+        return true;
+      }
+    })();
+
+    let fields: EncodableBitStringFields = new EncodableBitStringFields();
+    fields.put(UsRiField.MSPA_VERSION.toString(), new EncodableFixedInteger(6, UsRi.VERSION));
+    fields.put(
+      UsRiField.MSPA_COVERED_TRANSACTION.toString(),
+      new EncodableFixedInteger(2, 1).withValidator(nonNullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsRiField.MSPA_MODE.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsRiField.PROCESSING_NOTICE.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsRiField.SALE_OPT_OUT_NOTICE.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsRiField.SALE_OPT_OUT.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsRiField.TARGETED_ADVERTISING_OPT_OUT.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT.toString(),
+      new EncodableFixedInteger(2, 0).withValidator(nullableBooleanAsTwoBitIntegerValidator)
+    );
+    fields.put(
+      UsRiField.SENSITIVE_DATA_PROCESSING.toString(),
+      new EncodableFixedIntegerList(2, [0, 0, 0, 0, 0, 0, 0, 0]).withValidator(
+        nullableBooleanAsTwoBitIntegerListValidator
+      )
+    );
+    return fields;
+  }
+
+  // overriden
+  protected encodeSegment(fields: EncodableBitStringFields): string {
+    let bitString: string = this.bitStringEncoder.encode(fields, this.getFieldNames());
+    let encodedString: string = this.base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  // overriden
+  protected decodeSegment(encodedString: string, fields: EncodableBitStringFields): void {
+    if (encodedString == null || encodedString.length === 0) {
+      this.fields.reset(fields);
+    }
+    try {
+      let bitString: string = this.base64UrlEncoder.decode(encodedString);
+      this.bitStringEncoder.decode(bitString, this.getFieldNames(), fields);
+    } catch (e) {
+      throw new DecodingError("Unable to decode UsRiCoreSegment '" + encodedString + "'");
+    }
+  }
+}

--- a/modules/cmpapi/src/encoder/segment/UsRiGpcSegment.ts
+++ b/modules/cmpapi/src/encoder/segment/UsRiGpcSegment.ts
@@ -1,0 +1,56 @@
+import { AbstractBase64UrlEncoder } from "../base64/AbstractBase64UrlEncoder.js";
+import { CompressedBase64UrlEncoder } from "../base64/CompressedBase64UrlEncoder.js";
+import { BitStringEncoder } from "../bitstring/BitStringEncoder.js";
+import { EncodableBoolean } from "../datatype/EncodableBoolean.js";
+import { EncodableFixedInteger } from "../datatype/EncodableFixedInteger.js";
+import { DecodingError } from "../error/DecodingError.js";
+import { EncodableBitStringFields } from "../field/EncodableBitStringFields.js";
+import { UsRi_GPC_SEGMENT_FIELD_NAMES } from "../field/UsRiField.js";
+import { UsRiField } from "../field/UsRiField.js";
+import { AbstractLazilyEncodableSegment } from "./AbstractLazilyEncodableSegment.js";
+
+export class UsRiGpcSegment extends AbstractLazilyEncodableSegment<EncodableBitStringFields> {
+  private base64UrlEncoder: AbstractBase64UrlEncoder = CompressedBase64UrlEncoder.getInstance();
+  private bitStringEncoder: BitStringEncoder = BitStringEncoder.getInstance();
+
+  constructor(encodedString?: string) {
+    super();
+    if (encodedString) {
+      this.decode(encodedString);
+    }
+  }
+
+  // overriden
+  public getFieldNames(): string[] {
+    return UsRi_GPC_SEGMENT_FIELD_NAMES;
+  }
+
+  // overriden
+  protected initializeFields(): EncodableBitStringFields {
+    let fields: EncodableBitStringFields = new EncodableBitStringFields();
+    fields.put(UsRiField.GPC_SEGMENT_TYPE.toString(), new EncodableFixedInteger(2, 1));
+    fields.put(UsRiField.GPC_SEGMENT_INCLUDED.toString(), new EncodableBoolean(true));
+    fields.put(UsRiField.GPC.toString(), new EncodableBoolean(false));
+    return fields;
+  }
+
+  // overriden
+  protected encodeSegment(fields: EncodableBitStringFields): string {
+    let bitString: string = this.bitStringEncoder.encode(fields, this.getFieldNames());
+    let encodedString: string = this.base64UrlEncoder.encode(bitString);
+    return encodedString;
+  }
+
+  // overriden
+  protected decodeSegment(encodedString: string, fields: EncodableBitStringFields): void {
+    if (encodedString == null || encodedString.length === 0) {
+      this.fields.reset(fields);
+    }
+    try {
+      let bitString: string = this.base64UrlEncoder.decode(encodedString);
+      this.bitStringEncoder.decode(bitString, this.getFieldNames(), fields);
+    } catch (e) {
+      throw new DecodingError("Unable to decode UsRiGpcSegment '" + encodedString + "'");
+    }
+  }
+}

--- a/modules/cmpapi/src/encoder/segment/index.ts
+++ b/modules/cmpapi/src/encoder/segment/index.ts
@@ -34,6 +34,8 @@ export * from "./UsNatGpcSegment.js";
 export * from "./UspV1CoreSegment.js";
 export * from "./UsOrCoreSegment.js";
 export * from "./UsOrGpcSegment.js";
+export * from "./UsRiCoreSegment.js";
+export * from "./UsRiGpcSegment.js";
 export * from "./UsTnCoreSegment.js";
 export * from "./UsTnGpcSegment.js";
 export * from "./UsTxCoreSegment.js";

--- a/modules/cmpapi/test/GppModel.test.ts
+++ b/modules/cmpapi/test/GppModel.test.ts
@@ -60,6 +60,7 @@ describe("manifest.GppModel", (): void => {
     expect(gppModel.hasSection("usnj")).to.eql(false);
     expect(gppModel.hasSection("ustn")).to.eql(false);
     expect(gppModel.hasSection("usmn")).to.eql(false);
+    expect(gppModel.hasSection("usri")).to.eql(false);
 
     gppModel.setFieldValue("tcfeuv2", "Version", 2);
     gppModel.setFieldValue("tcfeuv2", "CmpId", 880);
@@ -86,6 +87,7 @@ describe("manifest.GppModel", (): void => {
     gppModel.setFieldValue("usnj", "Version", 1);
     gppModel.setFieldValue("ustn", "Version", 1);
     gppModel.setFieldValue("usmn", "Version", 1);
+    gppModel.setFieldValue("usri", "MspaVersion", 1);
 
     expect(gppModel.hasSection("tcfeuv2")).to.eql(true);
     expect(gppModel.hasSection("tcfcav1")).to.eql(true);
@@ -107,10 +109,11 @@ describe("manifest.GppModel", (): void => {
     expect(gppModel.hasSection("usnj")).to.eql(true);
     expect(gppModel.hasSection("ustn")).to.eql(true);
     expect(gppModel.hasSection("usmn")).to.eql(true);
+    expect(gppModel.hasSection("usri")).to.eql(true);
 
     let gppString = gppModel.encode();
     expect(gppString).to.eql(
-      "DBACOYs~CPSG_8APSG_8ANwAAAENAAFgAAAAAAAAAAAAAAAAAAAA.IAAA.YAAAAAAAAAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA"
+      "DBADOYtY~CPSG_8APSG_8ANwAAAENAAFgAAAAAAAAAAAAAAAAAAAA.IAAA.YAAAAAAAAAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAAAAA.QA"
     );
   });
 
@@ -411,7 +414,7 @@ describe("manifest.GppModel", (): void => {
 
   it("should decode defaults from all sections", (): void => {
     let gppString =
-      "DBACOYs~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA";
+      "DBADOYtY~CPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAAAA.QAAA.IAAA~BPSG_8APSG_8AAAAAAENAACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA~1---~BAAAAAAAAABA.QA~BAAAAABA.QA~BAAAABA~BAAAAEA.QA~BAAAAAQA~BAAAAAEA.QA~BAAAAABA~BAAAAABA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAABAA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BAAAAABA.QA~BAAAAAAAQA.QA~BAAAAAQA.QA~BAAAAAQA.QA~BQAAAAA.QA";
     let gppModel = new GppModel(gppString);
 
     expect(gppModel.hasSection("tcfeuv2")).to.eql(true);
@@ -434,6 +437,7 @@ describe("manifest.GppModel", (): void => {
     expect(gppModel.hasSection("usnj")).to.eql(true);
     expect(gppModel.hasSection("ustn")).to.eql(true);
     expect(gppModel.hasSection("usmn")).to.eql(true);
+    expect(gppModel.hasSection("usri")).to.eql(true);
   });
 
   it("should decode uspv1 section", (): void => {

--- a/modules/cmpapi/test/encoder/section/UsRi.test.ts
+++ b/modules/cmpapi/test/encoder/section/UsRi.test.ts
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+import { UsRiField } from "../../../src/encoder/field/UsRiField";
+import { UsRi } from "../../../src/encoder/section/UsRi";
+
+describe("manifest.section.UsRi", (): void => {
+  it("should encode default", (): void => {
+    let usRi = new UsRi();
+    expect(usRi.encode()).to.eql("BQAAAAA.QA");
+  });
+
+  it("should encode with all fields set", (): void => {
+    let usRi = new UsRi();
+
+    usRi.setFieldValue(UsRiField.MSPA_COVERED_TRANSACTION, 1);
+    usRi.setFieldValue(UsRiField.MSPA_MODE, 1);
+    usRi.setFieldValue(UsRiField.PROCESSING_NOTICE, 1);
+    usRi.setFieldValue(UsRiField.SALE_OPT_OUT_NOTICE, 1);
+    usRi.setFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT_NOTICE, 1);
+    usRi.setFieldValue(UsRiField.SALE_OPT_OUT, 1);
+    usRi.setFieldValue(UsRiField.TARGETED_ADVERTISING_OPT_OUT, 1);
+    usRi.setFieldValue(UsRiField.KNOWN_CHILD_SENSITIVE_DATA_CONSENTS, 1);
+    usRi.setFieldValue(UsRiField.ADDITIONAL_DATA_PROCESSING_CONSENT, 1);
+    usRi.setFieldValue(UsRiField.SENSITIVE_DATA_PROCESSING, [2, 1, 0, 2, 1, 0, 2, 1]);
+    usRi.setFieldValue(UsRiField.GPC, true);
+
+    expect(usRi.encode()).to.eql("BVVVkkk.YA");
+  });
+
+  it("should encode default with gpc segment excluded", (): void => {
+    let usRi = new UsRi();
+    usRi.setFieldValue(UsRiField.GPC_SEGMENT_INCLUDED, false);
+    expect(usRi.encode()).to.eql("BQAAAAA");
+  });
+
+  it("should throw an error if invalid values are set", (): void => {
+    let usRi = new UsRi();
+
+    expect(function () {
+      usRi.setFieldValue(UsRiField.MSPA_COVERED_TRANSACTION, 0);
+    }).to.throw();
+
+    expect(function () {
+      usRi.setFieldValue(UsRiField.SENSITIVE_DATA_PROCESSING, [0, 1, 2, 3, 1, 2, 0, 1]);
+    }).to.throw();
+  });
+
+  it("should decode", (): void => {
+    let usRi = new UsRi("BVVVkkk.YA");
+
+    expect(usRi.getFieldValue(UsRiField.MSPA_COVERED_TRANSACTION)).to.eql(1);
+    expect(usRi.getFieldValue(UsRiField.SENSITIVE_DATA_PROCESSING)).to.eql([2, 1, 0, 2, 1, 0, 2, 1]);
+    expect(usRi.getFieldValue(UsRiField.GPC)).to.eql(true);
+  });
+
+  it("should throw Error on garbage", (): void => {
+    expect(function () {
+      new UsRi("z").getFieldValue(UsRiField.PROCESSING_NOTICE);
+    }).to.throw("Unable to decode UsRiCoreSegment 'z'");
+  });
+});


### PR DESCRIPTION
## Summary

Implements the Rhode Island section per the GPP US-States/RI spec, registered as Section ID 27 (client-side API prefix `usri`).

- Adds `UsRi` section, `UsRiField` enum, `UsRiCoreSegment`, `UsRiGpcSegment` following the existing `UsMn` pattern.
- Registers the section in `Sections.ts`, `GppModel.ts`, and all three (`field`/`section`/`segment`) `index.ts` re-exports.
- Core subsection has 11 fields including `SensitiveDataProcessing` (N-Bitfield(2,8)) and `KnownChildSensitiveDataConsents`. The single `MspaMode` field replaces `MspaOptOutOptionMode` + `MspaServiceProviderMode`, and `MspaVersion` is the first field.

## Test plan

- [x] Added `UsRi.test.ts` covering encode default, encode all fields, GPC-segment exclusion, validation rejection, round-trip decode, and garbage input
- [x] Updated `GppModel.test.ts` "should default all sections" and "should decode defaults from all sections" to include UsRi
- [x] `npm test` on `modules/cmpapi`: **336 passing**